### PR TITLE
Fix incorrect sleep time input

### DIFF
--- a/Views/AddSleepPage.xaml.cs
+++ b/Views/AddSleepPage.xaml.cs
@@ -24,6 +24,12 @@ namespace MigraineTracker.Views
             var start = StartDatePicker.Date + StartTimePicker.Time;
             var end = EndDatePicker.Date + EndTimePicker.Time;
 
+            if (end <= start)
+            {
+                await DisplayAlert("Error", "End time must be after start time.", "OK");
+                return;
+            }
+
             var entry = new SleepEntry
             {
                 Id = Guid.NewGuid(),


### PR DESCRIPTION
## Summary
- validate end time in AddSleepPage

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e8749d4c8326b9a3c01bb48aaa53