### PR TITLE
Implement Shell TabBar with placeholder pages

### DIFF
--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -3,13 +3,29 @@
     x:Class="MigraineTracker.AppShell"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:MigraineTracker"
-    Shell.FlyoutBehavior="Flyout"
-    Title="MigraineTracker">
+    xmlns:views="clr-namespace:MigraineTracker.Views"
+    Shell.FlyoutBehavior="Disabled">
 
-    <ShellContent
-        Title="Home"
-        ContentTemplate="{DataTemplate local:MainPage}"
-        Route="MainPage" />
-
+    <TabBar
+        Shell.TabBarBackgroundColor="#FFFFFF"
+        Shell.TabBarForegroundColor="#000000"
+        Shell.TabBarTitleColor="#000000"
+        Shell.TabBarUnselectedColor="#95A0A9">
+        <ShellContent
+            Title="Dashboard"
+            Icon="ic_home.png"
+            ContentTemplate="{DataTemplate views:MainPage}" />
+        <ShellContent
+            Title="Logs"
+            Icon="ic_list.png"
+            ContentTemplate="{DataTemplate views:LogsPage}" />
+        <ShellContent
+            Title="Reports"
+            Icon="ic_chart.png"
+            ContentTemplate="{DataTemplate views:ReportsPage}" />
+        <ShellContent
+            Title="Settings"
+            Icon="ic_settings.png"
+            ContentTemplate="{DataTemplate views:SettingsPage}" />
+    </TabBar>
 </Shell>

--- a/MigraineTracker.csproj
+++ b/MigraineTracker.csproj
@@ -83,9 +83,21 @@
 	  <MauiXaml Update="Views\AddSupplementPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
-	  <MauiXaml Update="Views\AddWaterPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
+          <MauiXaml Update="Views\AddWaterPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\MainPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\LogsPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\ReportsPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\SettingsPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
 	</ItemGroup>
 
 </Project>

--- a/Views/LogsPage.xaml
+++ b/Views/LogsPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MigraineTracker.Views.LogsPage"
+             Title="Logs">
+    <StackLayout>
+        <Label Text="Logs Page" HorizontalOptions="Center" VerticalOptions="Center"/>
+    </StackLayout>
+</ContentPage>

--- a/Views/LogsPage.xaml.cs
+++ b/Views/LogsPage.xaml.cs
@@ -1,0 +1,11 @@
+using System;
+using Microsoft.Maui.Controls;
+namespace MigraineTracker.Views;
+
+public partial class LogsPage : ContentPage
+{
+    public LogsPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/Views/MainPage.xaml
+++ b/Views/MainPage.xaml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage
-    x:Class="MigraineTracker.MainPage"
+    x:Class="MigraineTracker.Views.MainPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     Title="Dashboard"

--- a/Views/MainPage.xaml.cs
+++ b/Views/MainPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using MigraineTracker.ViewModels;
-using MigraineTracker.Views;
-namespace MigraineTracker
+namespace MigraineTracker.Views
 {
     public partial class MainPage : ContentPage
     {

--- a/Views/ReportsPage.xaml
+++ b/Views/ReportsPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MigraineTracker.Views.ReportsPage"
+             Title="Reports">
+    <StackLayout>
+        <Label Text="Reports Page" HorizontalOptions="Center" VerticalOptions="Center"/>
+    </StackLayout>
+</ContentPage>

--- a/Views/ReportsPage.xaml.cs
+++ b/Views/ReportsPage.xaml.cs
@@ -1,0 +1,11 @@
+using System;
+using Microsoft.Maui.Controls;
+namespace MigraineTracker.Views;
+
+public partial class ReportsPage : ContentPage
+{
+    public ReportsPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/Views/SettingsPage.xaml
+++ b/Views/SettingsPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MigraineTracker.Views.SettingsPage"
+             Title="Settings">
+    <StackLayout>
+        <Label Text="Settings Page" HorizontalOptions="Center" VerticalOptions="Center"/>
+    </StackLayout>
+</ContentPage>

--- a/Views/SettingsPage.xaml.cs
+++ b/Views/SettingsPage.xaml.cs
@@ -1,0 +1,11 @@
+using System;
+using Microsoft.Maui.Controls;
+namespace MigraineTracker.Views;
+
+public partial class SettingsPage : ContentPage
+{
+    public SettingsPage()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- configure `AppShell.xaml` with bottom `TabBar`
- move `MainPage` into `Views` namespace
- add placeholder `LogsPage`, `ReportsPage`, `SettingsPage`
- include placeholder tab icons
- update `.csproj` for new XAML pages
- **remove placeholder tab icons**

## Testing
- `dotnet build MigraineTracker.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862eac996dc8326805291fc75a72875