### PR TITLE
Add consolidated logs page

### DIFF
--- a/ViewModels/LogsPageViewModel.cs
+++ b/ViewModels/LogsPageViewModel.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using MigraineTracker.Data;
+using MigraineTracker.Models;
+
+namespace MigraineTracker.ViewModels
+{
+    public enum LogItemType
+    {
+        Migraine,
+        Supplement,
+        Meal,
+        Water,
+        Sleep
+    }
+
+    public class LogItem
+    {
+        public Guid Id { get; set; }
+        public LogItemType ItemType { get; set; }
+        public DateTime Timestamp { get; set; }
+        public string Icon { get; set; } = string.Empty;
+        public string PrimaryText { get; set; } = string.Empty;
+        public string SubText { get; set; } = string.Empty;
+    }
+
+    public class LogGroup : ObservableCollection<LogItem>
+    {
+        public DateTime Date { get; }
+        public string Header => Date.ToString("yyyy-MM-dd");
+        public LogGroup(DateTime date, IEnumerable<LogItem> items) : base(items)
+        {
+            Date = date;
+        }
+    }
+
+    public partial class LogsPageViewModel : ObservableObject
+    {
+        public ObservableCollection<LogGroup> LogGroups { get; } = new();
+
+        public IRelayCommand<LogItem> DeleteCommand { get; }
+
+        public LogsPageViewModel()
+        {
+            DeleteCommand = new RelayCommand<LogItem>(DeleteItem);
+        }
+
+        public void LoadData()
+        {
+            LogGroups.Clear();
+            var items = new List<LogItem>();
+            using var db = new MigraineTrackerDbContext();
+
+            foreach (var m in db.Migraines.ToList())
+            {
+                var time = m.StartTime ?? m.Date;
+                items.Add(new LogItem
+                {
+                    Id = m.Id,
+                    ItemType = LogItemType.Migraine,
+                    Timestamp = time,
+                    Icon = "\uD83D\uDCA5",
+                    PrimaryText = $"Migraine  {new string('\u25CF', m.Severity)}   {m.Triggers}",
+                    SubText = $"{time:hh:mm tt}"
+                });
+            }
+
+            foreach (var s in db.Supplements.ToList())
+            {
+                var time = s.TimeTaken ?? s.Date;
+                items.Add(new LogItem
+                {
+                    Id = s.Id,
+                    ItemType = LogItemType.Supplement,
+                    Timestamp = time,
+                    Icon = "\uD83D\uDC8A",
+                    PrimaryText = $"{s.Name} {s.DosageMg}{s.DosageUnit}",
+                    SubText = $"{time:hh:mm tt}"
+                });
+            }
+
+            foreach (var m in db.Meals.ToList())
+            {
+                var time = m.Time ?? m.Date;
+                items.Add(new LogItem
+                {
+                    Id = m.Id,
+                    ItemType = LogItemType.Meal,
+                    Timestamp = time,
+                    Icon = "\uD83C\uDF7D",
+                    PrimaryText = $"{m.MealType}: {m.FoodItems}",
+                    SubText = $"{time:hh:mm tt}"
+                });
+            }
+
+            foreach (var w in db.WaterIntakes.ToList())
+            {
+                var time = w.Time ?? w.Date;
+                items.Add(new LogItem
+                {
+                    Id = w.Id,
+                    ItemType = LogItemType.Water,
+                    Timestamp = time,
+                    Icon = "\uD83D\uDCA7",
+                    PrimaryText = $"Water {w.VolumeMl} mL",
+                    SubText = $"{time:hh:mm tt}"
+                });
+            }
+
+            foreach (var s in db.Sleeps.ToList())
+            {
+                var time = s.SleepStart ?? s.Date;
+                items.Add(new LogItem
+                {
+                    Id = s.Id,
+                    ItemType = LogItemType.Sleep,
+                    Timestamp = time,
+                    Icon = "\uD83D\uDE34",
+                    PrimaryText = $"Sleep {s.DurationHours:F1}h {s.Quality}",
+                    SubText = s.SleepStart.HasValue && s.SleepEnd.HasValue
+                        ? $"{s.SleepStart:hh:mm tt} – {s.SleepEnd:hh:mm tt}"
+                        : string.Empty
+                });
+            }
+
+            var grouped = items
+                .OrderByDescending(i => i.Timestamp)
+                .GroupBy(i => i.Timestamp.Date)
+                .OrderByDescending(g => g.Key);
+
+            foreach (var grp in grouped)
+            {
+                var groupItems = grp.OrderByDescending(i => i.Timestamp);
+                LogGroups.Add(new LogGroup(grp.Key, groupItems));
+            }
+        }
+
+        private void DeleteItem(LogItem item)
+        {
+            var group = LogGroups.FirstOrDefault(g => g.Contains(item));
+            if (group != null)
+            {
+                group.Remove(item);
+                if (group.Count == 0)
+                    LogGroups.Remove(group);
+            }
+
+            using var db = new MigraineTrackerDbContext();
+            switch (item.ItemType)
+            {
+                case LogItemType.Migraine:
+                    db.Migraines.Remove(new MigraineEntry { Id = item.Id });
+                    break;
+                case LogItemType.Supplement:
+                    db.Supplements.Remove(new SupplementEntry { Id = item.Id });
+                    break;
+                case LogItemType.Meal:
+                    db.Meals.Remove(new MealEntry { Id = item.Id });
+                    break;
+                case LogItemType.Water:
+                    db.WaterIntakes.Remove(new WaterIntakeEntry { Id = item.Id });
+                    break;
+                case LogItemType.Sleep:
+                    db.Sleeps.Remove(new SleepEntry { Id = item.Id });
+                    break;
+            }
+            db.SaveChanges();
+        }
+    }
+}

--- a/Views/LogsPage.xaml
+++ b/Views/LogsPage.xaml
@@ -1,9 +1,44 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="MigraineTracker.Views.LogsPage"
-             Title="Logs">
-    <StackLayout>
-        <Label Text="Logs Page" HorizontalOptions="Center" VerticalOptions="Center"/>
-    </StackLayout>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:vm="clr-namespace:MigraineTracker.ViewModels"
+    x:Class="MigraineTracker.Views.LogsPage"
+    x:Name="LogsPageRoot"
+    Title="Logs">
+    <ContentPage.BindingContext>
+        <vm:LogsPageViewModel />
+    </ContentPage.BindingContext>
+
+    <CollectionView ItemsSource="{Binding LogGroups}" IsGrouped="True">
+        <CollectionView.GroupHeaderTemplate>
+            <DataTemplate>
+                <Label Text="{Binding Header}"
+                       FontAttributes="Bold"
+                       BackgroundColor="#EEE"
+                       Padding="10,5" />
+            </DataTemplate>
+        </CollectionView.GroupHeaderTemplate>
+        <CollectionView.ItemTemplate>
+            <DataTemplate>
+                <SwipeView>
+                    <SwipeView.RightItems>
+                        <SwipeItems>
+                            <SwipeItem Text="Delete"
+                                       BackgroundColor="Red"
+                                       Command="{Binding BindingContext.DeleteCommand, Source={x:Reference LogsPageRoot}}"
+                                       CommandParameter="{Binding .}" />
+                        </SwipeItems>
+                    </SwipeView.RightItems>
+                    <Grid Padding="10" ColumnDefinitions="30,*">
+                        <Label Text="{Binding Icon}" FontSize="20" />
+                        <StackLayout Grid.Column="1" Spacing="2">
+                            <Label Text="{Binding PrimaryText}" FontAttributes="Bold" />
+                            <Label Text="{Binding SubText}" FontSize="12" TextColor="Gray" />
+                        </StackLayout>
+                    </Grid>
+                </SwipeView>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
 </ContentPage>

--- a/Views/LogsPage.xaml.cs
+++ b/Views/LogsPage.xaml.cs
@@ -1,11 +1,22 @@
-using System;
 using Microsoft.Maui.Controls;
+using MigraineTracker.ViewModels;
+
 namespace MigraineTracker.Views;
 
 public partial class LogsPage : ContentPage
 {
+    private readonly LogsPageViewModel vm;
+
     public LogsPage()
     {
         InitializeComponent();
+        vm = BindingContext as LogsPageViewModel ?? new LogsPageViewModel();
+        BindingContext = vm;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        vm.LoadData();
     }
 }


### PR DESCRIPTION
## Summary
- implement grouped log data view in **LogsPage**
- add `LogsPageViewModel` with delete support
- bind LogsPage to its view model and populate on appearing

## Testing
- `dotnet build MigraineTracker.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f39385608326b2b7c26f84b3a0df