### PR TITLE
Add Reports page with daily timeline

### DIFF
--- a/ViewModels/ReportsPageViewModel.cs
+++ b/ViewModels/ReportsPageViewModel.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using CommunityToolkit.Mvvm.ComponentModel;
+using MigraineTracker.Data;
+using MigraineTracker.Models;
+
+namespace MigraineTracker.ViewModels;
+
+public class ReportItem
+{
+    public DateTime Time { get; set; }
+    public string Icon { get; set; } = string.Empty;
+    public string Text { get; set; } = string.Empty;
+}
+
+public partial class ReportsPageViewModel : ObservableObject
+{
+    private DateTime _selectedDate = DateTime.Today;
+    public DateTime SelectedDate
+    {
+        get => _selectedDate;
+        set
+        {
+            if (SetProperty(ref _selectedDate, value))
+            {
+                LoadData();
+            }
+        }
+    }
+
+    public ObservableCollection<ReportItem> Items { get; } = new();
+
+    public void LoadData()
+    {
+        Items.Clear();
+        var list = new List<ReportItem>();
+        var date = SelectedDate.Date;
+        using var db = new MigraineTrackerDbContext();
+
+        foreach (var s in db.Sleeps.Where(s => s.Date == date).ToList())
+        {
+            var time = s.SleepStart ?? date;
+            list.Add(new ReportItem
+            {
+                Time = time,
+                Icon = "\uD83D\uDE34", // 😴
+                Text = $"Sleep {s.DurationHours:F1}h {s.Quality}"
+            });
+        }
+
+        foreach (var m in db.Migraines.Where(m => m.Date == date).ToList())
+        {
+            var time = m.StartTime ?? date;
+            list.Add(new ReportItem
+            {
+                Time = time,
+                Icon = "\uD83D\uDCA5", // 💥
+                Text = $"Migraine {m.Severity}/5 {m.Triggers}"
+            });
+        }
+
+        foreach (var meal in db.Meals.Where(meal => meal.Date == date).ToList())
+        {
+            var time = meal.Time ?? date;
+            list.Add(new ReportItem
+            {
+                Time = time,
+                Icon = "\uD83C\uDF7D", // 🍽
+                Text = $"{meal.MealType}: {meal.FoodItems}"
+            });
+        }
+
+        foreach (var s in db.Supplements.Where(s => s.Date == date).ToList())
+        {
+            var time = s.TimeTaken ?? date;
+            list.Add(new ReportItem
+            {
+                Time = time,
+                Icon = "\uD83D\uDC8A", // 💊
+                Text = $"{s.Name} {s.DosageMg}{s.DosageUnit}"
+            });
+        }
+
+        foreach (var w in db.WaterIntakes.Where(w => w.Date == date).ToList())
+        {
+            var time = w.Time ?? date;
+            list.Add(new ReportItem
+            {
+                Time = time,
+                Icon = "\uD83D\uDCA7", // 💧
+                Text = $"Water {w.VolumeMl} mL"
+            });
+        }
+
+        foreach (var item in list.OrderBy(i => i.Time))
+            Items.Add(item);
+    }
+
+    public string BuildMarkdown()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"# Diary for {SelectedDate:yyyy-MM-dd}");
+        foreach (var item in Items.OrderBy(i => i.Time))
+        {
+            sb.AppendLine($"{item.Time:HH:mm} {item.Icon} {item.Text}");
+        }
+        return sb.ToString();
+    }
+}

--- a/Views/ReportsPage.xaml
+++ b/Views/ReportsPage.xaml
@@ -1,9 +1,30 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="MigraineTracker.Views.ReportsPage"
-             Title="Reports">
-    <StackLayout>
-        <Label Text="Reports Page" HorizontalOptions="Center" VerticalOptions="Center"/>
-    </StackLayout>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:vm="clr-namespace:MigraineTracker.ViewModels"
+    x:Class="MigraineTracker.Views.ReportsPage"
+    x:Name="ReportsRoot"
+    Title="Reports">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Share" Clicked="OnShareClicked" />
+    </ContentPage.ToolbarItems>
+    <ContentPage.BindingContext>
+        <vm:ReportsPageViewModel />
+    </ContentPage.BindingContext>
+
+    <VerticalStackLayout Padding="10" Spacing="10">
+        <DatePicker Date="{Binding SelectedDate}" />
+        <CollectionView ItemsSource="{Binding Items}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid ColumnDefinitions="60,30,*" Padding="5">
+                        <Label Text="{Binding Time, StringFormat='{0:HH:mm}'}" />
+                        <Label Grid.Column="1" Text="{Binding Icon}" FontSize="18" HorizontalOptions="Center" />
+                        <Label Grid.Column="2" Text="{Binding Text}" />
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </VerticalStackLayout>
 </ContentPage>

--- a/Views/ReportsPage.xaml.cs
+++ b/Views/ReportsPage.xaml.cs
@@ -1,11 +1,34 @@
 using System;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.ApplicationModel.DataTransfer;
+using MigraineTracker.ViewModels;
+
 namespace MigraineTracker.Views;
 
 public partial class ReportsPage : ContentPage
 {
+    private readonly ReportsPageViewModel vm;
+
     public ReportsPage()
     {
         InitializeComponent();
+        vm = BindingContext as ReportsPageViewModel ?? new ReportsPageViewModel();
+        BindingContext = vm;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        vm.LoadData();
+    }
+
+    private async void OnShareClicked(object sender, EventArgs e)
+    {
+        var markdown = vm.BuildMarkdown();
+        await Share.RequestAsync(new ShareTextRequest
+        {
+            Text = markdown,
+            Title = "Migraine Diary"
+        });
     }
 }


### PR DESCRIPTION
## Summary
- implement `ReportsPageViewModel` for daily timeline aggregation
- build new XAML UI showing day picker, timeline list and Share button
- hook up `ReportsPage` code-behind to view model and share functionality

## Testing
- `dotnet build -t:Restore,Build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862f80440488326944f14f7754faa69