### PR TITLE
Remove unused counter from MainPage

### DIFF
--- a/Views/MainPage.xaml.cs
+++ b/Views/MainPage.xaml.cs
@@ -3,7 +3,6 @@ namespace MigraineTracker.Views
 {
     public partial class MainPage : ContentPage
     {
-        int count = 0;
         private MainPageViewModel vm;
 
 
@@ -21,10 +20,6 @@ namespace MigraineTracker.Views
             vm.LoadTodayMeals();
             vm.LoadTodayWater();
             vm.LoadLatestSleep();
-        }
-        private void OnCounterClicked(object sender, EventArgs e)
-        {
-
         }
         private async void OnAddMigraineClicked(object sender, EventArgs e)
         {


### PR DESCRIPTION
## Summary
- clean up `MainPage.xaml.cs` by removing unused `count` field
- drop empty `OnCounterClicked` handler

## Testing
- `dotnet build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630002a68c832681f85057564feb25