### PR TITLE
Fix supplement display aggregation

### DIFF
--- a/ViewModels/AddSupplementViewModel.cs
+++ b/ViewModels/AddSupplementViewModel.cs
@@ -15,7 +15,7 @@ namespace MigraineTracker.ViewModels
     {
         public DateTime BatchDate { get; set; }
         public List<SupplementEntry> Items { get; set; }
-        public string BatchDescription => string.Join(", ", Items.Select(i => $"{i.Name} {i.DosageMg}{i.DosageUnit}"));
+        public string BatchDescription => string.Join(", ", Items.Select(i => $"{i.Name} {i.DosageMg} {i.DosageUnit}"));
     }
 
     public partial class AddSupplementViewModel : ObservableObject

--- a/ViewModels/LogsPageViewModel.cs
+++ b/ViewModels/LogsPageViewModel.cs
@@ -79,7 +79,7 @@ namespace MigraineTracker.ViewModels
                     ItemType = LogItemType.Supplement,
                     Timestamp = time,
                     Icon = "\uD83D\uDC8A",
-                    PrimaryText = $"{s.Name} {s.DosageMg}{s.DosageUnit}",
+                    PrimaryText = $"{s.Name} {s.DosageMg} {s.DosageUnit}",
                     SubText = $"{time:hh:mm tt}"
                 });
             }

--- a/ViewModels/MainPageViewModel.cs
+++ b/ViewModels/MainPageViewModel.cs
@@ -96,10 +96,21 @@ namespace MigraineTracker.ViewModels
             {
                 var todaySupps = await db.Supplements
                     .Where(s => s.Date == DateTime.Today)
-                    .Select(s => $"{s.Name} {s.DosageMg}{s.DosageUnit}")
+                    .GroupBy(s => new { s.Name, s.DosageUnit })
+                    .Select(g => new
+                    {
+                        g.Key.Name,
+                        g.Key.DosageUnit,
+                        TotalDosage = g.Sum(x => x.DosageMg)
+                    })
+                    .OrderBy(r => r.Name)
                     .ToListAsync();
 
-                SupplementList = string.Join("   • ", todaySupps);
+                var list = todaySupps
+                    .Select(r => $"{r.Name} {r.TotalDosage} {r.DosageUnit}")
+                    .ToList();
+
+                SupplementList = string.Join("   • ", list);
             }
         }
         public async Task LoadTodayMealsAsync()

--- a/ViewModels/ReportsPageViewModel.cs
+++ b/ViewModels/ReportsPageViewModel.cs
@@ -81,7 +81,7 @@ public partial class ReportsPageViewModel : ObservableObject
             {
                 Time = time,
                 Icon = "\uD83D\uDC8A", // 💊
-                Text = $"{s.Name} {s.DosageMg}{s.DosageUnit}"
+                Text = $"{s.Name} {s.DosageMg} {s.DosageUnit}"
             });
         }
 


### PR DESCRIPTION
## Summary
- aggregate daily supplement dosages by name + unit
- show dosage unit with spaces across view models

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686308c28ce48326a81b9367bc6872c8