### PR TITLE
Optimize dashboard loading

### DIFF
--- a/Views/MainPage.xaml.cs
+++ b/Views/MainPage.xaml.cs
@@ -15,11 +15,10 @@ namespace MigraineTracker.Views
         protected override async void OnAppearing()
         {
             base.OnAppearing();
-            await vm.LoadLatestMigraineAsync();  // Refresh when page comes back into view
-            await vm.LoadTodaySupplementsAsync();
-            await vm.LoadTodayMealsAsync();
-            await vm.LoadTodayWaterAsync();
-            await vm.LoadLatestSleepAsync();
+            if (!vm.IsLoaded)
+            {
+                await vm.LoadDashboardAsync();
+            }
         }
         private async void OnAddMigraineClicked(object sender, EventArgs e)
         {


### PR DESCRIPTION
## Summary
- load dashboard data concurrently in a new `LoadDashboardAsync`
- add `_loaded` tracking and expose `IsLoaded`
- update `OnAppearing` to avoid unnecessary reloads
- provide `ForceRefreshAsync` to reload after adding data

## Testing
- `dotnet build MigraineTracker.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863677a34f08326893e4c5b0a9b65da