### PR TITLE
Force light theme

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -7,6 +7,10 @@ namespace MigraineTracker
         {
             InitializeComponent();
 
+            // Force the application to always use the light theme
+            // regardless of the device's system setting.
+            App.Current.UserAppTheme = AppTheme.Light;
+
             using (var db = new MigraineTrackerDbContext())
             {
                 db.Database.EnsureCreated();


### PR DESCRIPTION
## Summary
- configure the app to always use light theme

## Testing
- `dotnet build MigraineTracker.sln -clp:ErrorsOnly` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686373df30d48326976faed86685972d