### PR TITLE
Rename Logs page to Timeline

### DIFF
--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -16,9 +16,9 @@
             Icon="ic_home.png"
             ContentTemplate="{DataTemplate views:MainPage}" />
         <ShellContent
-            Title="Logs"
+            Title="Timeline"
             Icon="ic_list.png"
-            ContentTemplate="{DataTemplate views:LogsPage}" />
+            ContentTemplate="{DataTemplate views:TimelinePage}" />
         <ShellContent
             Title="Reports"
             Icon="ic_chart.png"

--- a/MigraineTracker.csproj
+++ b/MigraineTracker.csproj
@@ -89,7 +89,7 @@
           <MauiXaml Update="Views\MainPage.xaml">
             <Generator>MSBuild:Compile</Generator>
           </MauiXaml>
-          <MauiXaml Update="Views\LogsPage.xaml">
+          <MauiXaml Update="Views\TimelinePage.xaml">
             <Generator>MSBuild:Compile</Generator>
           </MauiXaml>
           <MauiXaml Update="Views\ReportsPage.xaml">

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A lightweight .NET MAUI app for logging migraine episodes and daily factors.
 ## Features
 - Add migraine episodes (start/end, severity, triggers, notes)
 - Log meals, water, supplements, sleep
-- View and delete entries in the **Logs** page
+- View and delete entries in the **Timeline** page
 - Quick trend reports (more coming)
 
 ## Build & Run

--- a/ViewModels/TimelinePageViewModel.cs
+++ b/ViewModels/TimelinePageViewModel.cs
@@ -39,13 +39,13 @@ namespace MigraineTracker.ViewModels
         }
     }
 
-    public partial class LogsPageViewModel : ObservableObject
+    public partial class TimelinePageViewModel : ObservableObject
     {
         public ObservableCollection<LogGroup> LogGroups { get; } = new();
 
         public IRelayCommand<LogItem> DeleteCommand { get; }
 
-        public LogsPageViewModel()
+        public TimelinePageViewModel()
         {
             DeleteCommand = new RelayCommand<LogItem>(DeleteItem);
         }

--- a/Views/TimelinePage.xaml
+++ b/Views/TimelinePage.xaml
@@ -3,11 +3,11 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:vm="clr-namespace:MigraineTracker.ViewModels"
-    x:Class="MigraineTracker.Views.LogsPage"
-    x:Name="LogsPageRoot"
-    Title="Logs">
+    x:Class="MigraineTracker.Views.TimelinePage"
+    x:Name="TimelinePageRoot"
+    Title="Timeline">
     <ContentPage.BindingContext>
-        <vm:LogsPageViewModel />
+        <vm:TimelinePageViewModel />
     </ContentPage.BindingContext>
 
     <CollectionView ItemsSource="{Binding LogGroups}" IsGrouped="True">
@@ -26,7 +26,7 @@
                         <SwipeItems>
                             <SwipeItem Text="Delete"
                                        BackgroundColor="Red"
-                                       Command="{Binding BindingContext.DeleteCommand, Source={x:Reference LogsPageRoot}}"
+                                       Command="{Binding BindingContext.DeleteCommand, Source={x:Reference TimelinePageRoot}}"
                                        CommandParameter="{Binding .}" />
                         </SwipeItems>
                     </SwipeView.RightItems>

--- a/Views/TimelinePage.xaml.cs
+++ b/Views/TimelinePage.xaml.cs
@@ -3,14 +3,14 @@ using MigraineTracker.ViewModels;
 
 namespace MigraineTracker.Views;
 
-public partial class LogsPage : ContentPage
+public partial class TimelinePage : ContentPage
 {
-    private readonly LogsPageViewModel vm;
+    private readonly TimelinePageViewModel vm;
 
-    public LogsPage()
+    public TimelinePage()
     {
         InitializeComponent();
-        vm = BindingContext as LogsPageViewModel ?? new LogsPageViewModel();
+        vm = BindingContext as TimelinePageViewModel ?? new TimelinePageViewModel();
         BindingContext = vm;
     }
 


### PR DESCRIPTION
## Summary
- rename Logs page, code-behind, and view model to `Timeline`
- update navigation references and build metadata
- update README wording

## Testing
- `dotnet build MigraineTracker.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686457639a9c832695402f0556a0f247