### PR TITLE
Adjust migraine severity scale

### DIFF
--- a/Models/MigraineEntry.cs
+++ b/Models/MigraineEntry.cs
@@ -12,7 +12,7 @@ namespace MigraineTracker.Models
         public DateTime Date { get; set; }
         public DateTime? StartTime { get; set; }
         public DateTime? EndTime { get; set; }
-        public int Severity { get; set; } // 1–5 (or whatever scale you use)
+        public int Severity { get; set; } // 1–10 (or whatever scale you use)
         public string? Triggers { get; set; } // e.g. "Stress;Lack of sleep"
         public string? Notes { get; set; }
     }

--- a/ViewModels/ReportsPageViewModel.cs
+++ b/ViewModels/ReportsPageViewModel.cs
@@ -59,7 +59,7 @@ public partial class ReportsPageViewModel : ObservableObject
             {
                 Time = time,
                 Icon = "\uD83D\uDCA5", // 💥
-                Text = $"Migraine {m.Severity}/5 {m.Triggers}"
+                Text = $"Migraine {m.Severity}/10 {m.Triggers}"
             });
         }
 

--- a/Views/AddMigrainePage.xaml
+++ b/Views/AddMigrainePage.xaml
@@ -18,8 +18,8 @@
             <Label Text="End Time"/>
             <TimePicker x:Name="EndTimePicker" />
 
-            <Label Text="Severity (1-5)"/>
-            <Slider x:Name="SeveritySlider" Minimum="1" Maximum="5" Value="3" />
+            <Label Text="Severity (1-10)"/>
+            <Slider x:Name="SeveritySlider" Minimum="1" Maximum="10" Value="5" />
 
             <Label Text="Triggers"/>
             <Entry x:Name="TriggersEntry" Placeholder="e.g. Stress, Lack of sleep"/>


### PR DESCRIPTION
## Summary
- update comment for Severity property
- support severity scale 1-10 in AddMigrainePage UI
- show new scale on reports

## Testing
- `dotnet build MigraineTracker.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645c2c683c83269ac0f995ce5098ad