### PR TITLE
Improve severity slider interaction

### DIFF
--- a/Views/AddMigrainePage.xaml
+++ b/Views/AddMigrainePage.xaml
@@ -19,7 +19,38 @@
             <TimePicker x:Name="EndTimePicker" />
 
             <Label Text="Severity (1-10)"/>
-            <Slider x:Name="SeveritySlider" Minimum="1" Maximum="10" Value="5" />
+            <Slider x:Name="SeveritySlider"
+                    Minimum="1"
+                    Maximum="10"
+                    Value="5"
+                    ValueChanged="SeveritySlider_ValueChanged" />
+            <Label x:Name="SeverityValueLabel"
+                   HorizontalOptions="Center"
+                   Text="{Binding Source={x:Reference SeveritySlider}, Path=Value, StringFormat='Selected: {0:F0}'}" />
+            <Grid ColumnSpacing="0" Margin="0,0,0,10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Label Text="1" Grid.Column="0" HorizontalOptions="Center" />
+                <Label Text="2" Grid.Column="1" HorizontalOptions="Center" />
+                <Label Text="3" Grid.Column="2" HorizontalOptions="Center" />
+                <Label Text="4" Grid.Column="3" HorizontalOptions="Center" />
+                <Label Text="5" Grid.Column="4" HorizontalOptions="Center" />
+                <Label Text="6" Grid.Column="5" HorizontalOptions="Center" />
+                <Label Text="7" Grid.Column="6" HorizontalOptions="Center" />
+                <Label Text="8" Grid.Column="7" HorizontalOptions="Center" />
+                <Label Text="9" Grid.Column="8" HorizontalOptions="Center" />
+                <Label Text="10" Grid.Column="9" HorizontalOptions="Center" />
+            </Grid>
 
             <Label Text="Triggers"/>
             <Entry x:Name="TriggersEntry" Placeholder="e.g. Stress, Lack of sleep"/>

--- a/Views/AddMigrainePage.xaml.cs
+++ b/Views/AddMigrainePage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using MigraineTracker.Data;
 using MigraineTracker.Models;
+using Microsoft.Maui.Controls;
 
 
 namespace MigraineTracker.Views
@@ -43,6 +44,17 @@ namespace MigraineTracker.Views
         private async void OnCancelClicked(object sender, EventArgs e)
         {
             await Navigation.PopAsync();
+        }
+
+        private void SeveritySlider_ValueChanged(object sender, ValueChangedEventArgs e)
+        {
+            int rounded = (int)Math.Round(e.NewValue);
+
+            if (rounded != (int)e.NewValue)
+            {
+                SeveritySlider.Value = rounded;
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- show currently selected migraine severity
- display discrete tick marks 1–10 below the slider
- round severity to nearest integer when slider changes

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645f1bda408326b0f22d1a0a0f8e3b