### PR TITLE
Enable date range export in reports

### DIFF
--- a/Views/ReportsPage.xaml
+++ b/Views/ReportsPage.xaml
@@ -14,7 +14,12 @@
     </ContentPage.BindingContext>
 
     <VerticalStackLayout Padding="10" Spacing="10">
-        <DatePicker Date="{Binding SelectedDate}" />
+        <HorizontalStackLayout Spacing="10">
+            <Label Text="Start" FontAttributes="Bold" VerticalTextAlignment="Center" />
+            <DatePicker Date="{Binding StartDate}" Format="yyyy-MM-dd" />
+            <Label Text="End" FontAttributes="Bold" Margin="20,0,0,0" VerticalTextAlignment="Center" />
+            <DatePicker Date="{Binding EndDate}" Format="yyyy-MM-dd" />
+        </HorizontalStackLayout>
         <CollectionView ItemsSource="{Binding Items}">
             <CollectionView.ItemTemplate>
                 <DataTemplate>

--- a/Views/ReportsPage.xaml.cs
+++ b/Views/ReportsPage.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.ApplicationModel.DataTransfer;
+using Microsoft.Maui.Storage;
 using MigraineTracker.ViewModels;
 
 namespace MigraineTracker.Views;
@@ -25,10 +26,14 @@ public partial class ReportsPage : ContentPage
     private async void OnShareClicked(object sender, EventArgs e)
     {
         var markdown = vm.BuildMarkdown();
-        await Share.RequestAsync(new ShareTextRequest
+        var fileName = $"MigraineDiary_{vm.StartDate:yyyyMMdd}_{vm.EndDate:yyyyMMdd}.md";
+        var filePath = Path.Combine(FileSystem.CacheDirectory, fileName);
+        File.WriteAllText(filePath, markdown);
+
+        await Share.RequestAsync(new ShareFileRequest
         {
-            Text = markdown,
-            Title = "Migraine Diary"
+            Title = "Migraine Diary",
+            File = new ShareFile(filePath)
         });
     }
 }


### PR DESCRIPTION
## Summary
- allow selecting start and end dates on the reports page
- collect report items for all days in the range
- generate markdown for the range and export as a file
- align date pickers horizontally with labels

## Testing
- `dotnet build MigraineTracker.sln -v:q` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864693170248326a1e708a3cc6bf4e3