### PR TITLE
Update Visual Studio instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A lightweight .NET MAUI app for logging migraine episodes and daily factors.
 - View and delete entries in the **Timeline** page
 - Quick trend reports (more coming)
 
-## Build & Run
-```bash
-dotnet build MigraineTracker.sln     # compile
-dotnet run -t:Run                    # launch for current target
-```
+## Getting Started
+1. Install **Visual Studio 2022** with the **.NET MAUI** workload.
+2. Clone this repository and open `MigraineTracker.sln` in Visual Studio.
+3. Select an Android or iOS emulator/device from the toolbar.
+4. Use Visual Studio's **Run** or **Debug** command to build and launch the app.


### PR DESCRIPTION
## Summary
- replace build instructions with Visual Studio 2022 setup steps

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a06527988326a89f2e06a324b802