### PR TITLE
Add supplement name suggestions

### DIFF
--- a/ViewModels/AddSupplementViewModel.cs
+++ b/ViewModels/AddSupplementViewModel.cs
@@ -24,6 +24,8 @@ namespace MigraineTracker.ViewModels
 
         public ObservableCollection<SupplementBatchVM> RecentBatches { get; } = new();
 
+        public ObservableCollection<string> SupplementNameSuggestions { get; } = new();
+
         public AddSupplementViewModel()
         {
             // Start with one row by default
@@ -79,6 +81,7 @@ namespace MigraineTracker.ViewModels
                 }
                 await db.SaveChangesAsync();
             }
+            await LoadSupplementNamesAsync();
             SupplementDrafts.Clear();
             SupplementDrafts.Add(new SupplementEntryDraft()); // Reset to one row
             await Shell.Current.DisplayAlert("Saved", "Supplements saved!", "OK");
@@ -129,6 +132,25 @@ namespace MigraineTracker.ViewModels
                             Items = items
                         });
                     }
+                }
+            }
+        }
+
+        public async Task LoadSupplementNamesAsync()
+        {
+            SupplementNameSuggestions.Clear();
+            using (var db = new MigraineTrackerDbContext())
+            {
+                var names = await db.Supplements
+                    .Where(s => !string.IsNullOrEmpty(s.Name))
+                    .Select(s => s.Name!)
+                    .Distinct()
+                    .OrderBy(n => n)
+                    .ToListAsync();
+
+                foreach (var name in names)
+                {
+                    SupplementNameSuggestions.Add(name);
                 }
             }
         }

--- a/Views/AddSupplementPage.xaml
+++ b/Views/AddSupplementPage.xaml
@@ -40,7 +40,9 @@
                     <DataTemplate>
                         <Frame BorderColor="#e0e0e0" CornerRadius="8">
                             <VerticalStackLayout>
-                                <Entry Placeholder="Name" Text="{Binding Name, Mode=TwoWay}" />
+                                <AutoSuggestBox Placeholder="Name"
+                                                Text="{Binding Name, Mode=TwoWay}"
+                                                ItemsSource="{Binding Source={x:Reference ThisPage}, Path=BindingContext.SupplementNameSuggestions}" />
                                 <Entry Placeholder="Dosage" Keyboard="Numeric" Text="{Binding DosageMg, Mode=TwoWay}" />
                                 <Entry Placeholder="Unit" Text="{Binding DosageUnit, Mode=TwoWay}" />
                                 <TimePicker Time="{Binding TimeTaken, Mode=TwoWay}" />

--- a/Views/AddSupplementPage.xaml.cs
+++ b/Views/AddSupplementPage.xaml.cs
@@ -15,6 +15,7 @@ namespace MigraineTracker.Views
             if (BindingContext is AddSupplementViewModel vm)
             {
                 await vm.LoadRecentBatchesAsync();
+                await vm.LoadSupplementNamesAsync();
             }
         }
     }


### PR DESCRIPTION
## Summary
- add `SupplementNameSuggestions` collection
- reload names after saving
- load names on page open
- use AutoSuggestBox for supplement name entry

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68662dbcd0448326b2eb506e58734df2