### PR TITLE
Add manual backup export and import

### DIFF
--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -23,10 +23,9 @@
             Title="Reports"
             Icon="ic_chart.png"
             ContentTemplate="{DataTemplate views:ReportsPage}" />
-        <!--Hide settings page--> 
-        <!--<ShellContent
+        <ShellContent
             Title="Settings"
             Icon="ic_settings.png"
-            ContentTemplate="{DataTemplate views:SettingsPage}" />-->
+            ContentTemplate="{DataTemplate views:SettingsPage}" />
     </TabBar>
 </Shell>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A lightweight .NET MAUI app for logging migraine episodes and daily factors.
 - Log meals, water, supplements, sleep
 - View and delete entries in the **Timeline** page
 - Quick trend reports (more coming)
+- Manual export/import backups from the **Settings** tab
 
 ## Project Structure
 

--- a/Services/BackupService.cs
+++ b/Services/BackupService.cs
@@ -1,0 +1,34 @@
+using System;
+using Microsoft.Maui.Storage;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace MigraineTracker.Services
+{
+    public static class BackupService
+    {
+        public static async Task<string> ExportBackupAsync()
+        {
+            string dbPath = Path.Combine(FileSystem.AppDataDirectory, "migraine.db");
+            string documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            string destPath = Path.Combine(documents, $"migraine_backup_{DateTime.Now:yyyyMMdd_HHmmss}.db");
+            using FileStream source = File.Open(dbPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using FileStream dest = File.Create(destPath);
+            await source.CopyToAsync(dest);
+            return destPath;
+        }
+
+        public static async Task ImportBackupAsync(string sourcePath)
+        {
+            if (string.IsNullOrWhiteSpace(sourcePath) || !File.Exists(sourcePath))
+                throw new FileNotFoundException("Backup file not found", sourcePath);
+
+            string dbPath = Path.Combine(FileSystem.AppDataDirectory, "migraine.db");
+
+            // Overwrite the existing database with the selected backup
+            using FileStream source = File.OpenRead(sourcePath);
+            using FileStream dest = File.Create(dbPath);
+            await source.CopyToAsync(dest);
+        }
+    }
+}

--- a/Views/SettingsPage.xaml
+++ b/Views/SettingsPage.xaml
@@ -3,7 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="MigraineTracker.Views.SettingsPage"
              Title="Settings">
-    <StackLayout>
-        <Label Text="Settings Page" HorizontalOptions="Center" VerticalOptions="Center"/>
+    <StackLayout Padding="20" Spacing="20">
+        <Label Text="Settings" FontSize="20" FontAttributes="Bold" />
+        <Button Text="Export Backup" Clicked="OnExportClicked" />
+        <Button Text="Import Backup" Clicked="OnImportClicked" />
     </StackLayout>
 </ContentPage>

--- a/Views/SettingsPage.xaml.cs
+++ b/Views/SettingsPage.xaml.cs
@@ -1,5 +1,8 @@
 using System;
 using Microsoft.Maui.Controls;
+using MigraineTracker.Services;
+using Microsoft.Maui.Storage;
+
 namespace MigraineTracker.Views;
 
 public partial class SettingsPage : ContentPage
@@ -7,5 +10,21 @@ public partial class SettingsPage : ContentPage
     public SettingsPage()
     {
         InitializeComponent();
+    }
+
+    private async void OnExportClicked(object sender, EventArgs e)
+    {
+        string path = await BackupService.ExportBackupAsync();
+        await DisplayAlert("Backup Exported", $"Backup saved to:\n{path}", "OK");
+    }
+
+    private async void OnImportClicked(object sender, EventArgs e)
+    {
+        var file = await FilePicker.Default.PickAsync();
+        if (file == null)
+            return;
+
+        await BackupService.ImportBackupAsync(file.FullPath);
+        await DisplayAlert("Backup Imported", "The backup has been restored.", "OK");
     }
 }


### PR DESCRIPTION
## Summary
- wire Settings page back into the tab bar
- implement `BackupService.ImportBackupAsync` and wire up a new "Import Backup" button
- show both export/import options in the Settings page
- document manual backup import/export in README

## Testing
- `dotnet build -bl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab7e7d0a08326830a746f54ce98f5