### PR TITLE
Add storage permission checks

### DIFF
--- a/Platforms/Android/AndroidManifest.xml
+++ b/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.INTERNET" />
+        <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+        <uses-permission android:name="android.permission.INTERNET" />
+        <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+        <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 </manifest>

--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ A lightweight .NET MAUI app for logging migraine episodes and daily factors.
 
 The app has been tested on a **3120 × 1440** display (e.g., *Galaxy S25 Ultra*).  
 If your device’s screen size differs, simply create an Android emulator with the same resolution in **Visual Studio 2022 → Android Device Manager** and give it a quick spin.
+
+## Permissions
+
+Android builds require the `WRITE_EXTERNAL_STORAGE` and `READ_EXTERNAL_STORAGE` permissions for the backup import/export feature.

--- a/Views/SettingsPage.xaml.cs
+++ b/Views/SettingsPage.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.Maui.Controls;
 using MigraineTracker.Services;
 using Microsoft.Maui.Storage;
+using Microsoft.Maui.ApplicationModel;
 
 namespace MigraineTracker.Views;
 
@@ -14,12 +15,26 @@ public partial class SettingsPage : ContentPage
 
     private async void OnExportClicked(object sender, EventArgs e)
     {
+        var status = await Permissions.RequestAsync<Permissions.StorageWrite>();
+        if (status != PermissionStatus.Granted)
+        {
+            await DisplayAlert("Permission Required", "Storage permission was denied.", "OK");
+            return;
+        }
+
         string path = await BackupService.ExportBackupAsync();
         await DisplayAlert("Backup Exported", $"Backup saved to:\n{path}", "OK");
     }
 
     private async void OnImportClicked(object sender, EventArgs e)
     {
+        var status = await Permissions.RequestAsync<Permissions.StorageRead>();
+        if (status != PermissionStatus.Granted)
+        {
+            await DisplayAlert("Permission Required", "Storage permission was denied.", "OK");
+            return;
+        }
+
         var file = await FilePicker.Default.PickAsync();
         if (file == null)
             return;


### PR DESCRIPTION
## Summary
- request storage permissions before exporting/importing backups
- add external storage permissions to the Android manifest
- document required permissions in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686abe6b9dd883268b40a792c5633d50