### PR TITLE
Fix Android backup export path

### DIFF
--- a/Services/BackupService.cs
+++ b/Services/BackupService.cs
@@ -11,6 +11,7 @@ namespace MigraineTracker.Services
         {
             string dbPath = Path.Combine(FileSystem.AppDataDirectory, "migraine.db");
             string documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            Directory.CreateDirectory(documents);
             string destPath = Path.Combine(documents, $"migraine_backup_{DateTime.Now:yyyyMMdd_HHmmss}.db");
             using FileStream source = File.Open(dbPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using FileStream dest = File.Create(destPath);


### PR DESCRIPTION
## Summary
- ensure Android backup folder exists before creating the file

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac27dca508326a697ddd822f24c64