### PR TITLE
Add Android folder picker for backup export

### DIFF
--- a/Platforms/Android/FolderPicker.android.cs
+++ b/Platforms/Android/FolderPicker.android.cs
@@ -1,0 +1,41 @@
+using Android.App;
+using Android.Content;
+using Microsoft.Maui.ApplicationModel;
+
+namespace MigraineTracker.Services;
+
+public static partial class FolderPicker
+{
+    static TaskCompletionSource<string?>? _tcs;
+    const int RequestCode = 4242;
+
+    public static partial Task<string?> PickFolderAsync()
+    {
+        var activity = Platform.CurrentActivity ?? throw new InvalidOperationException("No current Activity");
+        _tcs = new TaskCompletionSource<string?>();
+
+        var intent = new Intent(Intent.ActionOpenDocumentTree);
+        intent.AddFlags(ActivityFlags.GrantReadUriPermission | ActivityFlags.GrantWriteUriPermission | ActivityFlags.GrantPersistableUriPermission);
+        activity.StartActivityForResult(intent, RequestCode);
+
+        return _tcs.Task;
+    }
+
+    internal static void OnActivityResult(int requestCode, Result resultCode, Intent? data)
+    {
+        if (requestCode != RequestCode)
+            return;
+
+        if (resultCode == Result.Ok && data?.Data != null)
+        {
+            var uri = data.Data;
+            var flags = data.Flags & (ActivityFlags.GrantReadUriPermission | ActivityFlags.GrantWriteUriPermission);
+            Platform.CurrentActivity!.ContentResolver.TakePersistableUriPermission(uri!, flags);
+            _tcs?.TrySetResult(uri!.ToString());
+        }
+        else
+        {
+            _tcs?.TrySetResult(null);
+        }
+    }
+}

--- a/Platforms/Android/MainActivity.cs
+++ b/Platforms/Android/MainActivity.cs
@@ -1,4 +1,5 @@
 ﻿using Android.App;
+using Android.Content;
 using Android.Content.PM;
 using Android.OS;
 
@@ -7,5 +8,10 @@ namespace MigraineTracker
     [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
+        protected override void OnActivityResult(int requestCode, Result resultCode, Intent? data)
+        {
+            base.OnActivityResult(requestCode, resultCode, data);
+            MigraineTracker.Services.FolderPicker.OnActivityResult(requestCode, resultCode, data);
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A lightweight .NET MAUI app for logging migraine episodes and daily factors.
 - Log meals, water, supplements, sleep
 - View and delete entries in the **Timeline** page
 - Quick trend reports (more coming)
-- Manual export/import backups from the **Settings** tab
+- Manual export/import backups from the **Settings** tab (Android export lets you choose the destination folder)
 
 ## Project Structure
 
@@ -34,3 +34,4 @@ If your device’s screen size differs, simply create an Android emulator with t
 ## Permissions
 
 Android builds require the `WRITE_EXTERNAL_STORAGE` and `READ_EXTERNAL_STORAGE` permissions for the backup import/export feature.
+During export you will be prompted with Android's folder picker to choose where the backup file is saved.

--- a/Services/BackupService.cs
+++ b/Services/BackupService.cs
@@ -7,12 +7,12 @@ namespace MigraineTracker.Services
 {
     public static class BackupService
     {
-        public static async Task<string> ExportBackupAsync()
+        public static async Task<string> ExportBackupAsync(string? directory = null)
         {
             string dbPath = Path.Combine(FileSystem.AppDataDirectory, "migraine.db");
-            string documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            Directory.CreateDirectory(documents);
-            string destPath = Path.Combine(documents, $"migraine_backup_{DateTime.Now:yyyyMMdd_HHmmss}.db");
+            directory ??= Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            Directory.CreateDirectory(directory);
+            string destPath = Path.Combine(directory, $"migraine_backup_{DateTime.Now:yyyyMMdd_HHmmss}.db");
             using FileStream source = File.Open(dbPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using FileStream dest = File.Create(destPath);
             await source.CopyToAsync(dest);

--- a/Services/FolderPicker.cs
+++ b/Services/FolderPicker.cs
@@ -1,0 +1,6 @@
+namespace MigraineTracker.Services;
+
+public static partial class FolderPicker
+{
+    public static partial Task<string?> PickFolderAsync();
+}

--- a/Views/SettingsPage.xaml.cs
+++ b/Views/SettingsPage.xaml.cs
@@ -22,7 +22,11 @@ public partial class SettingsPage : ContentPage
             return;
         }
 
-        string path = await BackupService.ExportBackupAsync();
+        string? directory = await FolderPicker.PickFolderAsync();
+        if (string.IsNullOrEmpty(directory))
+            return;
+
+        string path = await BackupService.ExportBackupAsync(directory);
         await DisplayAlert("Backup Exported", $"Backup saved to:\n{path}", "OK");
     }
 


### PR DESCRIPTION
## Summary
- add folder picker service with Android implementation
- support choosing export directory in BackupService
- integrate folder picker into SettingsPage
- handle activity results in MainActivity
- document export folder selection

## Testing
- `dotnet build MigraineTracker.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aca6166ac8326adad2c5165190f62