### PR TITLE
Implement Android content URI backup

### DIFF
--- a/Services/BackupService.cs
+++ b/Services/BackupService.cs
@@ -2,6 +2,11 @@ using System;
 using Microsoft.Maui.Storage;
 using System.IO;
 using System.Threading.Tasks;
+#if ANDROID
+using Android.App;
+using Android.Net;
+using AndroidX.DocumentFile.Provider;
+#endif
 
 namespace MigraineTracker.Services
 {
@@ -10,12 +15,39 @@ namespace MigraineTracker.Services
         public static async Task<string> ExportBackupAsync(string? directory = null)
         {
             string dbPath = Path.Combine(FileSystem.AppDataDirectory, "migraine.db");
+
+            if (!File.Exists(dbPath))
+                throw new FileNotFoundException("Database not found", dbPath);
+
             directory ??= Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            if (string.IsNullOrWhiteSpace(directory))
+                throw new ArgumentException("Destination directory is invalid", nameof(directory));
+
+#if ANDROID
+            if (directory.StartsWith("content://", StringComparison.OrdinalIgnoreCase))
+            {
+                Uri uri = Uri.Parse(directory);
+                var folder = DocumentFile.FromTreeUri(Application.Context, uri)
+                             ?? throw new InvalidOperationException("Unable to access destination directory");
+
+                string fileName = $"migraine_backup_{DateTime.Now:yyyyMMdd_HHmmss}.db";
+                var destDoc = folder.CreateFile("application/octet-stream", fileName)
+                             ?? throw new InvalidOperationException("Unable to create destination file");
+
+                using FileStream source = File.Open(dbPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var destStream = Application.Context.ContentResolver.OpenOutputStream(destDoc.Uri)
+                                     ?? throw new InvalidOperationException("Unable to open destination stream");
+
+                await source.CopyToAsync(destStream);
+                return destDoc.Uri.ToString();
+            }
+#endif
+
             Directory.CreateDirectory(directory);
             string destPath = Path.Combine(directory, $"migraine_backup_{DateTime.Now:yyyyMMdd_HHmmss}.db");
-            using FileStream source = File.Open(dbPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            using FileStream dest = File.Create(destPath);
-            await source.CopyToAsync(dest);
+            using FileStream sourceFile = File.Open(dbPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using FileStream destFile = File.Create(destPath);
+            await sourceFile.CopyToAsync(destFile);
             return destPath;
         }
 


### PR DESCRIPTION
## Summary
- enable Android URI support when exporting backups
- create `DocumentFile` for `content://` locations
- copy the database to the chosen document tree

## Testing
- `dotnet build --no-restore` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad8cb1c5c832693939d6288ee56ab