### PR TITLE
Fix missing FolderPicker implementations on non-Android targets

### DIFF
--- a/Platforms/MacCatalyst/FolderPicker.maccatalyst.cs
+++ b/Platforms/MacCatalyst/FolderPicker.maccatalyst.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+
+namespace MigraineTracker.Services;
+
+public static partial class FolderPicker
+{
+    public static partial Task<string?> PickFolderAsync()
+    {
+        string documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        return Task.FromResult<string?>(documents);
+    }
+}

--- a/Platforms/Windows/FolderPicker.windows.cs
+++ b/Platforms/Windows/FolderPicker.windows.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+
+namespace MigraineTracker.Services;
+
+public static partial class FolderPicker
+{
+    public static partial Task<string?> PickFolderAsync()
+    {
+        string documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        return Task.FromResult<string?>(documents);
+    }
+}

--- a/Platforms/iOS/FolderPicker.ios.cs
+++ b/Platforms/iOS/FolderPicker.ios.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+
+namespace MigraineTracker.Services;
+
+public static partial class FolderPicker
+{
+    public static partial Task<string?> PickFolderAsync()
+    {
+        string documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        return Task.FromResult<string?>(documents);
+    }
+}


### PR DESCRIPTION
## Summary
- add default implementations of `FolderPicker.PickFolderAsync` for iOS, MacCatalyst and Windows

## Testing
- `dotnet build MigraineTracker.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686adc1d280c8326b1f222027c1c649c