### PR TITLE
Fix inconsistent fonts on Timeline and Reports pages

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -4,6 +4,11 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
 
     <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
+                <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
 
         <!-- Colors -->
         <Color x:Key="PrimaryBlue">#007ACC</Color>
@@ -57,6 +62,6 @@
             <Setter Property="Padding" Value="12,6"/>
             <Setter Property="HorizontalOptions" Value="End"/>
         </Style>
-
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/Views/ReportsPage.xaml
+++ b/Views/ReportsPage.xaml
@@ -21,11 +21,11 @@
 
         <HorizontalStackLayout Spacing="20">
             <HorizontalStackLayout Spacing="6">
-                <Label Text="Start" FontAttributes="Bold" VerticalOptions="Center" />
+                <Label Text="Start" FontAttributes="Bold" FontFamily="OpenSansSemibold" VerticalOptions="Center" />
                 <DatePicker Date="{Binding StartDate}" />
             </HorizontalStackLayout>
             <HorizontalStackLayout Spacing="6">
-                <Label Text="End" FontAttributes="Bold" VerticalOptions="Center" />
+                <Label Text="End" FontAttributes="Bold" FontFamily="OpenSansSemibold" VerticalOptions="Center" />
                 <DatePicker Date="{Binding EndDate}" />
             </HorizontalStackLayout>
         </HorizontalStackLayout>

--- a/Views/TimelinePage.xaml
+++ b/Views/TimelinePage.xaml
@@ -15,6 +15,7 @@
             <DataTemplate>
                 <Label Text="{Binding Header}"
                        FontAttributes="Bold"
+                       FontFamily="OpenSansSemibold"
                        BackgroundColor="#EEE"
                        Padding="10,5" />
             </DataTemplate>
@@ -33,7 +34,7 @@
                     <Grid Padding="10" ColumnDefinitions="30,*">
                         <Label Text="{Binding Icon}" FontSize="20" />
                         <StackLayout Grid.Column="1" Spacing="2">
-                            <Label Text="{Binding PrimaryText}" FontAttributes="Bold" />
+                            <Label Text="{Binding PrimaryText}" FontAttributes="Bold" FontFamily="OpenSansSemibold" />
                             <Label Text="{Binding SubText}" FontSize="12" TextColor="Gray" />
                         </StackLayout>
                     </Grid>


### PR DESCRIPTION
## Summary
- load shared font resources globally
- use OpenSansSemibold for bold labels on Timeline and Reports pages

## Testing
- `dotnet build -bl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af511db448326a7f07c2745b90117