### PR TITLE
Group reports by date

### DIFF
--- a/ViewModels/ReportsPageViewModel.cs
+++ b/ViewModels/ReportsPageViewModel.cs
@@ -17,6 +17,17 @@ public class ReportItem
     public string Text { get; set; } = string.Empty;
 }
 
+public class ReportGroup : ObservableCollection<ReportItem>
+{
+    public DateTime Date { get; }
+    public string Header => Date.ToString("MMMM d yyyy");
+
+    public ReportGroup(DateTime date, IEnumerable<ReportItem> items) : base(items)
+    {
+        Date = date;
+    }
+}
+
 
 public partial class ReportsPageViewModel : ObservableObject
 {
@@ -51,6 +62,7 @@ public partial class ReportsPageViewModel : ObservableObject
     }
 
     public ObservableCollection<ReportItem> Items { get; } = new();
+    public ObservableCollection<ReportGroup> ReportGroups { get; } = new();
 
     public async Task LoadDataAsync()
     {
@@ -148,6 +160,17 @@ public partial class ReportsPageViewModel : ObservableObject
 
         foreach (var item in list.OrderBy(i => i.Time))
             Items.Add(item);
+
+        ReportGroups.Clear();
+        var grouped = Items
+            .GroupBy(i => i.Time.Date)
+            .OrderBy(g => g.Key);
+
+        foreach (var grp in grouped)
+        {
+            var groupItems = grp.OrderBy(i => i.Time);
+            ReportGroups.Add(new ReportGroup(grp.Key, groupItems));
+        }
     }
 
     public string BuildMarkdown()

--- a/Views/ReportsPage.xaml
+++ b/Views/ReportsPage.xaml
@@ -30,7 +30,16 @@
             </HorizontalStackLayout>
         </HorizontalStackLayout>
 
-        <CollectionView Grid.Row="1" ItemsSource="{Binding Items}">
+        <CollectionView Grid.Row="1" ItemsSource="{Binding ReportGroups}" IsGrouped="True">
+            <CollectionView.GroupHeaderTemplate>
+                <DataTemplate>
+                    <Label Text="{Binding Header}"
+                           FontAttributes="Bold"
+                           FontFamily="OpenSansSemibold"
+                           BackgroundColor="#EEE"
+                           Padding="10,5" />
+                </DataTemplate>
+            </CollectionView.GroupHeaderTemplate>
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Grid ColumnDefinitions="60,30,*" Padding="5">


### PR DESCRIPTION
## Summary
- create `ReportGroup` type
- group report items by date in `ReportsPageViewModel`
- add date headers to the Reports view

## Testing
- `dotnet build MigraineTracker.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af7e53b888326b484395d9efddb94