### PR TITLE
Fix Android release IL trimming

### DIFF
--- a/MigraineTracker.csproj
+++ b/MigraineTracker.csproj
@@ -39,7 +39,12 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
-	</PropertyGroup>
+        </PropertyGroup>
+
+        <!-- Disable IL trimming on Android release builds to preserve EF Core metadata -->
+        <PropertyGroup Condition="'$(Configuration)' == 'Release' AND '$(TargetFramework)' == 'net9.0-android'">
+            <PublishTrimmed>false</PublishTrimmed>
+        </PropertyGroup>
 
 	<ItemGroup>
 		<!-- App Icon -->

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ If your device’s screen size differs, simply create an Android emulator with t
 Android builds require the `WRITE_EXTERNAL_STORAGE` and `READ_EXTERNAL_STORAGE` permissions for the backup import/export feature.
 During export you will be prompted with Android's folder picker to choose where the backup file is saved.
 
+## Release Builds
+
+Android release builds enable IL trimming which can remove Entity Framework Core metadata and break the backup import. The `MigraineTracker.csproj` file disables trimming for Android release builds so that database operations work correctly.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- disable IL trimming for Android release builds
- document the release trimming note in README

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686afd055c58832696aa4e65d57e5d64