### PR TITLE
Disable AOT for Android release builds

### DIFF
--- a/MigraineTracker.csproj
+++ b/MigraineTracker.csproj
@@ -43,7 +43,9 @@
 
         <!-- Disable IL trimming on Android release builds to preserve EF Core metadata -->
         <PropertyGroup Condition="'$(Configuration)' == 'Release' AND '$(TargetFramework)' == 'net9.0-android'">
+            <!-- Disable trimming for Entity Framework Core metadata and turn off AOT compilation -->
             <PublishTrimmed>false</PublishTrimmed>
+            <RunAOTCompilation>false</RunAOTCompilation>
         </PropertyGroup>
 
 	<ItemGroup>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ During export you will be prompted with Android's folder picker to choose where 
 
 ## Release Builds
 
-Android release builds enable IL trimming which can remove Entity Framework Core metadata and break the backup import. The `MigraineTracker.csproj` file disables trimming for Android release builds so that database operations work correctly.
+Android release builds enable IL trimming which can remove Entity Framework Core metadata and break the backup import. The `MigraineTracker.csproj` file disables trimming for Android release builds so that database operations work correctly and also turns off AOT compilation for that configuration.
 
 ## License
 


### PR DESCRIPTION
## Summary
- disable AOT compilation for Android release builds to avoid XA1030 error
- document AOT being disabled in README

## Testing
- `dotnet build MigraineTracker.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b01ae19bc83268a0188bb39c51e2c