### PR TITLE
Fix trimming for EF Core

### DIFF
--- a/MigraineTracker.csproj
+++ b/MigraineTracker.csproj
@@ -38,15 +38,14 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
-        </PropertyGroup>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+    </PropertyGroup>
 
-        <!-- Disable IL trimming on Android release builds to preserve EF Core metadata -->
-        <PropertyGroup Condition="'$(Configuration)' == 'Release' AND '$(TargetFramework)' == 'net9.0-android'">
-            <!-- Disable trimming for Entity Framework Core metadata and turn off AOT compilation -->
-            <PublishTrimmed>false</PublishTrimmed>
-            <RunAOTCompilation>false</RunAOTCompilation>
-        </PropertyGroup>
+    <!-- Preserve EF Core metadata when trimming -->
+    <ItemGroup>
+        <TrimmerRootDescriptor Include="PreserveEFCore.xml" />
+    </ItemGroup>
+
 
 	<ItemGroup>
 		<!-- App Icon -->

--- a/PreserveEFCore.xml
+++ b/PreserveEFCore.xml
@@ -1,0 +1,10 @@
+<linker>
+  <assembly fullname="MigraineTracker">
+    <type fullname="MigraineTracker.Data.MigraineTrackerDbContext" />
+    <type fullname="MigraineTracker.Models.MigraineEntry" />
+    <type fullname="MigraineTracker.Models.MealEntry" />
+    <type fullname="MigraineTracker.Models.SleepEntry" />
+    <type fullname="MigraineTracker.Models.SupplementEntry" />
+    <type fullname="MigraineTracker.Models.WaterIntakeEntry" />
+  </assembly>
+</linker>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ During export you will be prompted with Android's folder picker to choose where 
 
 ## Release Builds
 
-Android release builds enable IL trimming which can remove Entity Framework Core metadata and break the backup import. The `MigraineTracker.csproj` file disables trimming for Android release builds so that database operations work correctly and also turns off AOT compilation for that configuration.
+Android release builds enable IL trimming which can remove Entity Framework Core metadata and break the backup import. The project now keeps trimming enabled and uses a linker descriptor (`PreserveEFCore.xml`) referenced in `MigraineTracker.csproj` so that the required EF Core types are preserved.
 
 ## License
 


### PR DESCRIPTION
## Summary
- remove release property group that disabled trimming
- keep EF Core types when trimming with `PreserveEFCore.xml`
- reference descriptor from project
- update the README with new trimming instructions

## Testing
- `dotnet build MigraineTracker.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b09618c448326b9f30fc5751e0dab