### PR TITLE
Preserve EF Core models during trimming

### DIFF
--- a/PreserveEFCore.xml
+++ b/PreserveEFCore.xml
@@ -1,10 +1,10 @@
 <linker>
   <assembly fullname="MigraineTracker">
-    <type fullname="MigraineTracker.Data.MigraineTrackerDbContext" />
-    <type fullname="MigraineTracker.Models.MigraineEntry" />
-    <type fullname="MigraineTracker.Models.MealEntry" />
-    <type fullname="MigraineTracker.Models.SleepEntry" />
-    <type fullname="MigraineTracker.Models.SupplementEntry" />
-    <type fullname="MigraineTracker.Models.WaterIntakeEntry" />
+    <type fullname="MigraineTracker.Data.MigraineTrackerDbContext" preserve="all"/>
+    <type fullname="MigraineTracker.Models.MigraineEntry" preserve="all"/>
+    <type fullname="MigraineTracker.Models.MealEntry" preserve="all"/>
+    <type fullname="MigraineTracker.Models.SleepEntry" preserve="all"/>
+    <type fullname="MigraineTracker.Models.SupplementEntry" preserve="all"/>
+    <type fullname="MigraineTracker.Models.WaterIntakeEntry" preserve="all"/>
   </assembly>
 </linker>


### PR DESCRIPTION
## Summary
- update `PreserveEFCore.xml` so each type is preserved

## Testing
- `dotnet build MigraineTracker.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b15aa0a1c83269ea8e9902a7c9d02