### PR TITLE
Switch recent supplement batches to dropdown

### DIFF
--- a/ViewModels/AddSupplementViewModel.cs
+++ b/ViewModels/AddSupplementViewModel.cs
@@ -16,6 +16,7 @@ namespace MigraineTracker.ViewModels
         public DateTime BatchDate { get; set; }
         public List<SupplementEntry> Items { get; set; }
         public string BatchDescription => string.Join(", ", Items.Select(i => $"{i.Name} {i.DosageMg} {i.DosageUnit}"));
+        public string DisplayText => $"{BatchDate:yyyy-MM-dd}: {BatchDescription}";
     }
 
     public partial class AddSupplementViewModel : ObservableObject
@@ -23,6 +24,17 @@ namespace MigraineTracker.ViewModels
         public ObservableCollection<SupplementEntryDraft> SupplementDrafts { get; } = new();
 
         public ObservableCollection<SupplementBatchVM> RecentBatches { get; } = new();
+
+        [ObservableProperty]
+        private SupplementBatchVM? selectedBatch;
+
+        partial void OnSelectedBatchChanged(SupplementBatchVM? value)
+        {
+            if (value != null)
+            {
+                UseBatch(value);
+            }
+        }
 
         public AddSupplementViewModel()
         {

--- a/Views/AddSupplementPage.xaml
+++ b/Views/AddSupplementPage.xaml
@@ -16,22 +16,11 @@
 
             <!-- Recent batches -->
             <Label Text="Pick from Recent Batches" FontAttributes="Bold"/>
-            <CollectionView ItemsSource="{Binding RecentBatches}" SelectionMode="None">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate>
-                        <Frame Margin="0,4" BorderColor="#e0e0e0" CornerRadius="8">
-                            <VerticalStackLayout>
-                                <Label Text="{Binding BatchDate, StringFormat='{0:yyyy-MM-dd}'}" FontAttributes="Bold"/>
-                                <Label Text="{Binding BatchDescription}" FontSize="13"/>
-                                <Button 
-                                    Text="Use this batch"
-                                    Command="{Binding Source={x:Reference ThisPage}, Path=BindingContext.UseBatchCommand}"
-                                    CommandParameter="{Binding .}"/>
-                            </VerticalStackLayout>
-                        </Frame>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
+            <Picker
+                Title="Select Batch"
+                ItemsSource="{Binding RecentBatches}"
+                ItemDisplayBinding="{Binding DisplayText}"
+                SelectedItem="{Binding SelectedBatch}" />
 
             <!-- Current supplements being added -->
             <Label Text="Supplements to Add" FontAttributes="Bold" Margin="0,16,0,0"/>


### PR DESCRIPTION
## Summary
- use DisplayText to show recent batch info
- add SelectedBatch property and auto-load selection
- show recent batches in a Picker rather than a list of cards

## Testing
- `dotnet build MigraineTracker.sln -v minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b42257b7c8326be1f4537672e1aca