### PR TITLE
Improve batch selection UI

### DIFF
--- a/Views/AddSupplementPage.xaml
+++ b/Views/AddSupplementPage.xaml
@@ -16,11 +16,27 @@
 
             <!-- Recent batches -->
             <Label Text="Pick from Recent Batches" FontAttributes="Bold"/>
-            <Picker
-                Title="Select Batch"
+            <CollectionView
                 ItemsSource="{Binding RecentBatches}"
-                ItemDisplayBinding="{Binding DisplayText}"
-                SelectedItem="{Binding SelectedBatch}" />
+                SelectionMode="Single"
+                SelectedItem="{Binding SelectedBatch}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Frame Padding="16,8" BorderColor="#e0e0e0" MinimumHeightRequest="56">
+                            <VerticalStackLayout Spacing="2">
+                                <Label
+                                    Text="{Binding BatchDate, StringFormat='{0:yyyy-MM-dd}'}"
+                                    FontAttributes="Bold"
+                                    FontSize="16" />
+                                <Label
+                                    Text="{Binding BatchDescription}"
+                                    FontSize="12"
+                                    LineBreakMode="WordWrap" />
+                            </VerticalStackLayout>
+                        </Frame>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
 
             <!-- Current supplements being added -->
             <Label Text="Supplements to Add" FontAttributes="Bold" Margin="0,16,0,0"/>


### PR DESCRIPTION
## Summary
- replace the recent batch Picker on AddSupplementPage with a CollectionView
- each batch row shows the date on one line and the supplement list beneath it
- add padding and minimum height to make rows easier to tap

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b44bef4c883269182305cfe01edf0