### PR TITLE
Add Android Health sleep sync

### DIFF
--- a/Platforms/Android/AndroidManifest.xml
+++ b/Platforms/Android/AndroidManifest.xml
@@ -5,4 +5,5 @@
         <uses-permission android:name="android.permission.INTERNET" />
         <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
         <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+        <uses-permission android:name="android.permission.health.READ_SLEEP" />
 </manifest>

--- a/Platforms/Android/HealthConnectService.android.cs
+++ b/Platforms/Android/HealthConnectService.android.cs
@@ -1,0 +1,47 @@
+#if ANDROID
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AndroidX.Health.Connect.Client;
+using AndroidX.Health.Connect.Client.Records;
+using AndroidX.Health.Connect.Client.Request;
+using AndroidX.Health.Connect.Client.Time;
+using Microsoft.Maui.ApplicationModel;
+using MigraineTracker.Models;
+
+namespace MigraineTracker.Services;
+
+public static partial class HealthConnectService
+{
+    public static partial async Task<SleepEntry?> GetLastSleepEntryAsync()
+    {
+        var context = Platform.AppContext ?? Android.App.Application.Context;
+        var client = new HealthConnectClient(context);
+
+        var end = Instant.Now;
+        var start = end.Minus(Duration.FromDays(7));
+
+        var request = new ReadRecordsRequest.Builder(typeof(SleepSessionRecord))
+            .SetTimeRangeFilter(TimeRangeFilter.Companion.Between(start, end))
+            .Build();
+
+        var response = await client.ReadRecordsAsync<SleepSessionRecord>(request);
+        var latest = response.Records
+            .OrderByDescending(r => r.EndTime)
+            .FirstOrDefault();
+
+        if (latest == null)
+            return null;
+
+        return new SleepEntry
+        {
+            Id = Guid.NewGuid(),
+            Date = latest.StartTime.ToDateTimeOffset().Date,
+            SleepStart = latest.StartTime.ToDateTimeOffset().DateTime,
+            SleepEnd = latest.EndTime.ToDateTimeOffset().DateTime,
+            Quality = "Fair",
+            Notes = "Imported from Health Connect"
+        };
+    }
+}
+#endif

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A lightweight .NET MAUI app for logging migraine episodes and daily factors.
 - View and delete entries in the **Timeline** page
 - Quick trend reports (more coming)
 - Manual export/import backups from the **Settings** tab (Android export lets you choose the destination folder)
+- Import the last sleep session from **Android Health** (Android only)
 
 ## Project Structure
 

--- a/Services/HealthConnectService.cs
+++ b/Services/HealthConnectService.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using MigraineTracker.Models;
+
+namespace MigraineTracker.Services;
+
+public static partial class HealthConnectService
+{
+    /// <summary>
+    /// Retrieves the most recent sleep session from Android Health Connect if available.
+    /// Returns <c>null</c> on other platforms or when no session is found.
+    /// </summary>
+    public static partial Task<SleepEntry?> GetLastSleepEntryAsync();
+}

--- a/Services/HealthConnectService.stub.cs
+++ b/Services/HealthConnectService.stub.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using MigraineTracker.Models;
+
+namespace MigraineTracker.Services;
+
+public static partial class HealthConnectService
+{
+    /// <summary>
+    /// Fallback implementation when Android Health Connect is not available.
+    /// </summary>
+    public static partial Task<SleepEntry?> GetLastSleepEntryAsync()
+        => Task.FromResult<SleepEntry?>(null);
+}

--- a/Views/AddSleepPage.xaml
+++ b/Views/AddSleepPage.xaml
@@ -37,9 +37,13 @@
               Placeholder="e.g. Snoring, low O₂"/>
 
       <!-- Actions -->
+      <Button Text="Import Last Sleep"
+              BackgroundColor="#F1F0F4"
+              TextColor="Black"
+              Clicked="OnImportClicked"/>
       <Button Text="Save"
-              BackgroundColor="#5D3EE4" 
-			  TextColor="White"
+              BackgroundColor="#5D3EE4"
+                          TextColor="White"
               Clicked="OnSaveClicked"/>
       <Button Text="Cancel"
               BackgroundColor="#F1F0F4" 

--- a/Views/AddSleepPage.xaml.cs
+++ b/Views/AddSleepPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using MigraineTracker.Data;
 using MigraineTracker.Models;
+using MigraineTracker.Services;
 using Microsoft.Maui.Controls;
 
 namespace MigraineTracker.Views
@@ -46,6 +47,23 @@ namespace MigraineTracker.Views
 
             await DisplayAlert("Saved", $"Sleep saved ({(end - start).TotalHours:F1}h)", "OK");
             await Shell.Current.GoToAsync("..");
+        }
+
+        private async void OnImportClicked(object sender, EventArgs e)
+        {
+            var entry = await HealthConnectService.GetLastSleepEntryAsync();
+            if (entry == null || entry.SleepStart == null || entry.SleepEnd == null)
+            {
+                await DisplayAlert("Health Connect", "No recent sleep found.", "OK");
+                return;
+            }
+
+            StartDatePicker.Date = entry.SleepStart.Value.Date;
+            StartTimePicker.Time = entry.SleepStart.Value.TimeOfDay;
+            EndDatePicker.Date = entry.SleepEnd.Value.Date;
+            EndTimePicker.Time = entry.SleepEnd.Value.TimeOfDay;
+            NotesEditor.Text = entry.Notes ?? string.Empty;
+            QualityPicker.SelectedItem = entry.Quality ?? "Fair";
         }
 
         private async void OnCancelClicked(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- add `HealthConnectService` with Android-specific implementation
- insert 'Import Last Sleep' button and handler in the sleep page
- update README feature list
- request Health Connect permission in AndroidManifest

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b56db74a88326975ef4e41e0a1400