### PR TITLE
Add Android sleep data reading

### DIFF
--- a/Platforms/Android/SleepDataService.android.cs
+++ b/Platforms/Android/SleepDataService.android.cs
@@ -1,0 +1,34 @@
+using Android.Content;
+using AndroidX.Health.Connect.Client;
+using AndroidX.Health.Connect.Client.Records;
+using AndroidX.Health.Connect.Client.Request;
+
+namespace MigraineTracker.Services;
+
+public static partial class SleepDataService
+{
+    public static partial async Task<SleepData?> GetLatestSleepAsync()
+    {
+        var context = Android.App.Application.Context;
+        var client = new HealthConnectClient(context);
+
+        var request = new ReadRecordsRequest.Builder(typeof(SleepSessionRecord))
+            .SetTimeRange(
+                DateTimeOffset.Now.AddDays(-7),
+                null,
+                DateTimeOffset.Now,
+                null)
+            .Build();
+
+        var response = await client.ReadRecordsAsync(request);
+        var record = response.Records
+            .OfType<SleepSessionRecord>()
+            .OrderByDescending(r => r.EndTime)
+            .FirstOrDefault();
+
+        if (record == null)
+            return null;
+
+        return new SleepData(record.StartTime.UtcDateTime, record.EndTime.UtcDateTime);
+    }
+}

--- a/Platforms/MacCatalyst/SleepDataService.maccatalyst.cs
+++ b/Platforms/MacCatalyst/SleepDataService.maccatalyst.cs
@@ -1,0 +1,9 @@
+namespace MigraineTracker.Services;
+
+public static partial class SleepDataService
+{
+    public static partial Task<SleepData?> GetLatestSleepAsync()
+    {
+        return Task.FromResult<SleepData?>(null);
+    }
+}

--- a/Platforms/Tizen/SleepDataService.tizen.cs
+++ b/Platforms/Tizen/SleepDataService.tizen.cs
@@ -1,0 +1,9 @@
+namespace MigraineTracker.Services;
+
+public static partial class SleepDataService
+{
+    public static partial Task<SleepData?> GetLatestSleepAsync()
+    {
+        return Task.FromResult<SleepData?>(null);
+    }
+}

--- a/Platforms/Windows/SleepDataService.windows.cs
+++ b/Platforms/Windows/SleepDataService.windows.cs
@@ -1,0 +1,9 @@
+namespace MigraineTracker.Services;
+
+public static partial class SleepDataService
+{
+    public static partial Task<SleepData?> GetLatestSleepAsync()
+    {
+        return Task.FromResult<SleepData?>(null);
+    }
+}

--- a/Platforms/iOS/SleepDataService.ios.cs
+++ b/Platforms/iOS/SleepDataService.ios.cs
@@ -1,0 +1,9 @@
+namespace MigraineTracker.Services;
+
+public static partial class SleepDataService
+{
+    public static partial Task<SleepData?> GetLatestSleepAsync()
+    {
+        return Task.FromResult<SleepData?>(null);
+    }
+}

--- a/Services/SleepDataService.cs
+++ b/Services/SleepDataService.cs
@@ -1,0 +1,11 @@
+namespace MigraineTracker.Services;
+
+public record SleepData(DateTime Start, DateTime End)
+{
+    public double DurationHours => (End - Start).TotalHours;
+}
+
+public static partial class SleepDataService
+{
+    public static partial Task<SleepData?> GetLatestSleepAsync();
+}

--- a/ViewModels/MainPageViewModel.cs
+++ b/ViewModels/MainPageViewModel.cs
@@ -4,6 +4,7 @@ using MigraineTracker.Data;
 using MigraineTracker.Models;
 using Microsoft.EntityFrameworkCore;
 using System.Linq;
+using MigraineTracker.Services;
 
 namespace MigraineTracker.ViewModels
 {
@@ -144,6 +145,17 @@ namespace MigraineTracker.ViewModels
         }
         public async Task LoadLatestSleepAsync()
         {
+#if ANDROID
+            var deviceSleep = await SleepDataService.GetLatestSleepAsync();
+            if (deviceSleep != null)
+            {
+                SleepSummary =
+                    $"{deviceSleep.DurationHours:F1} hr\n" +
+                    $"{deviceSleep.Start.ToLocalTime():hh:mm tt} – {deviceSleep.End.ToLocalTime():hh:mm tt}";
+                return;
+            }
+#endif
+
             using var db = new MigraineTrackerDbContext();
             var latest = await db.Sleeps
                 .OrderByDescending(s => s.Date)

--- a/Views/AddSleepPage.xaml.cs
+++ b/Views/AddSleepPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using MigraineTracker.Data;
 using MigraineTracker.Models;
+using MigraineTracker.Services;
 using Microsoft.Maui.Controls;
 
 namespace MigraineTracker.Views
@@ -17,7 +18,24 @@ namespace MigraineTracker.Views
             EndDatePicker.Date = today;
             StartTimePicker.Time = now;
             EndTimePicker.Time = now;
+#if ANDROID
+            _ = LoadFromDeviceAsync();
+#endif
         }
+
+#if ANDROID
+        private async Task LoadFromDeviceAsync()
+        {
+            var sleep = await SleepDataService.GetLatestSleepAsync();
+            if (sleep != null)
+            {
+                StartDatePicker.Date = sleep.Start.ToLocalTime().Date;
+                StartTimePicker.Time = sleep.Start.ToLocalTime().TimeOfDay;
+                EndDatePicker.Date = sleep.End.ToLocalTime().Date;
+                EndTimePicker.Time = sleep.End.ToLocalTime().TimeOfDay;
+            }
+        }
+#endif
 
         private async void OnSaveClicked(object sender, EventArgs e)
         {


### PR DESCRIPTION
## Summary
- create `SleepDataService` abstraction
- implement Android health connect reading for latest sleep data
- fall back to database for other platforms
- show device sleep record in dashboard and add sleep page

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b66aea624832696bf3a83d2dc70a1