### PR TITLE
Remove Health Connect dependency

### DIFF
--- a/Platforms/Android/SleepDataService.android.cs
+++ b/Platforms/Android/SleepDataService.android.cs
@@ -1,7 +1,7 @@
 using Android.Content;
-using AndroidX.Health.Connect.Client;
-using AndroidX.Health.Connect.Client.Records;
-using AndroidX.Health.Connect.Client.Request;
+using Android.Health.Connect;
+using Android.Health.Connect.Records;
+using Android.Health.Connect.Request;
 
 namespace MigraineTracker.Services;
 
@@ -10,7 +10,7 @@ public static partial class SleepDataService
     public static partial async Task<SleepData?> GetLatestSleepAsync()
     {
         var context = Android.App.Application.Context;
-        var client = new HealthConnectClient(context);
+        var manager = new HealthConnectManager(context);
 
         var request = new ReadRecordsRequest.Builder(typeof(SleepSessionRecord))
             .SetTimeRange(
@@ -20,15 +20,14 @@ public static partial class SleepDataService
                 null)
             .Build();
 
-        var response = await client.ReadRecordsAsync(request);
+        var response = await manager.ReadRecordsAsync(request);
         var record = response.Records
             .OfType<SleepSessionRecord>()
             .OrderByDescending(r => r.EndTime)
             .FirstOrDefault();
 
-        if (record == null)
-            return null;
-
-        return new SleepData(record.StartTime.UtcDateTime, record.EndTime.UtcDateTime);
+        return record == null
+            ? null
+            : new SleepData(record.StartTime.UtcDateTime, record.EndTime.UtcDateTime);
     }
 }


### PR DESCRIPTION
## Summary
- avoid using HealthConnect library on Android
- implement Health Connect using built-in package for GetLatestSleepAsync

## Testing
- `dotnet build MigraineTracker.sln -c Release` *(fails: `dotnet` not found)*


------
https://chatgpt.com/codex/tasks/task_e_686b6b39b060832695b882605224d200