### PR TITLE
Add posture field to migraine entries

### DIFF
--- a/Models/MigraineEntry.cs
+++ b/Models/MigraineEntry.cs
@@ -12,6 +12,11 @@ namespace MigraineTracker.Models
         public DateTime Date { get; set; }
         public DateTime? StartTime { get; set; }
         public DateTime? EndTime { get; set; }
+        /// <summary>
+        /// Body position when the migraine occurred.
+        /// "Supine", "SideLying", "Reclined30", "Seated", or "Standing".
+        /// </summary>
+        public string? Posture { get; set; }
         public int Severity { get; set; } // 1–10 (or whatever scale you use)
         public string? Triggers { get; set; } // e.g. "Stress;Lack of sleep"
         public string? Notes { get; set; }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A lightweight .NET MAUI app for logging migraine episodes and daily factors.
 
 
 ## Features
-- Add migraine episodes (start/end, severity, triggers, notes)
+- Add migraine episodes (start/end, posture, severity, triggers, notes)
 - Log meals, water, supplements, sleep
 - View and delete entries in the **Timeline** page
 - Quick trend reports (more coming)

--- a/Views/AddMigrainePage.xaml
+++ b/Views/AddMigrainePage.xaml
@@ -16,6 +16,17 @@
             <Label Text="End Time"/>
             <TimePicker x:Name="EndTimePicker" />
 
+            <Label Text="Posture"/>
+            <Picker x:Name="PosturePicker">
+                <Picker.Items>
+                    <x:String>Supine</x:String>
+                    <x:String>SideLying</x:String>
+                    <x:String>Reclined30</x:String>
+                    <x:String>Seated</x:String>
+                    <x:String>Standing</x:String>
+                </Picker.Items>
+            </Picker>
+
             <Label Text="Severity (1-10)"/>
             <Slider x:Name="SeveritySlider"
                     Minimum="1"

--- a/Views/AddMigrainePage.xaml.cs
+++ b/Views/AddMigrainePage.xaml.cs
@@ -24,6 +24,7 @@ namespace MigraineTracker.Views
                 Date = DatePicker.Date,
                 StartTime = DatePicker.Date + StartTimePicker.Time,
                 EndTime = DatePicker.Date + EndTimePicker.Time,
+                Posture = PosturePicker.SelectedItem?.ToString() ?? "Seated",
                 Severity = (int)SeveritySlider.Value,
                 Triggers = TriggersEntry.Text ?? "",
                 Notes = NotesEditor.Text ?? ""


### PR DESCRIPTION
## Summary
- allow posture logging on migraine entries
- add UI for posture selection and default to Seated in code
- document the new posture field in README

## Testing
- `dotnet build MigraineTracker.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882827960908326a5c4e189a0f6e81b