### PR TITLE
Filter out sleep older than a day

### DIFF
--- a/ViewModels/MainPageViewModel.cs
+++ b/ViewModels/MainPageViewModel.cs
@@ -145,7 +145,9 @@ namespace MigraineTracker.ViewModels
         public async Task LoadLatestSleepAsync()
         {
             using var db = new MigraineTrackerDbContext();
+            var cutoff = DateTime.Today.AddDays(-1);
             var latest = await db.Sleeps
+                .Where(s => (s.SleepEnd ?? s.Date) >= cutoff)
                 .OrderByDescending(s => s.Date)
                 .ThenByDescending(s => s.SleepEnd)
                 .FirstOrDefaultAsync();
@@ -160,7 +162,7 @@ namespace MigraineTracker.ViewModels
             }
             else
             {
-                SleepSummary = "No sleep logged yet.";
+                SleepSummary = "No recent sleep logged.";
             }
         }
         // Boilerplate for INotifyPropertyChanged


### PR DESCRIPTION
## Summary
- ignore older sleep entries in `LoadLatestSleepAsync`
- show `No recent sleep logged.` when nothing from the last day exists

## Testing
- `dotnet build -t:Restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882a27bc3408326a6de870375beb175